### PR TITLE
Fix Windows build issue

### DIFF
--- a/src/io/util.rs
+++ b/src/io/util.rs
@@ -152,13 +152,26 @@ pub fn get_version(data: &Value, category: &str, version: &str) -> Result<String
 pub fn exit_with_error(log_file: &SharedLogFile, error: &str) -> ! {
     log_error(log_file, error);
 
-    #[cfg(windows)]
-    clear().unwrap();
+    clear_screen();
 
     println!("{} {}", Status::error(), error);
     println!("\n{} Press Enter to exit...", Status::warning());
     let _ = io::stdin().read_line(&mut String::new());
     std::process::exit(1);
+}
+
+fn clear_screen() {
+    #[cfg(windows)]
+    {
+        let _ = std::process::Command::new("cmd")
+            .args(["/C", "cls"])
+            .status();
+    }
+
+    #[cfg(not(windows))]
+    {
+        let _ = std::process::Command::new("clear").status();
+    }
 }
 
 pub fn setup_ctrlc(should_stop: Arc<std::sync::atomic::AtomicBool>) {


### PR DESCRIPTION
Last PR (#10) introduced a build breakage on Windows.
Apologies for not testing on this platform before contributing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal now clears when the application exits due to an error, improving visibility of error messages across Windows and non-Windows systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->